### PR TITLE
Adding more flexibility to cfscript query highlighting

### DIFF
--- a/Cfscript.tmLanguage
+++ b/Cfscript.tmLanguage
@@ -596,7 +596,7 @@
             <array>
                 <dict>
                     <key>begin</key>
-                    <string>\.((?i:setsql))\("</string>
+                    <string>\.((?i:setsql))\(\s*["|']</string>
                     <key>beginCaptures</key>
                     <dict>
                         <key>1</key>
@@ -606,7 +606,7 @@
                         </dict>
                     </dict>
                     <key>end</key>
-                    <string>("\))</string>
+                    <string>(["|']\s*\))</string>
                     <key>endCaptures</key>
                     <dict>
                         <key>1</key>


### PR DESCRIPTION
For issue #12.

This pull request adds a little more flexibility to the cfscript query syntax highlighting by adding support for both double or single quotes, as well as spaces between the quotes and the open/close parentheses.
