### PR TITLE
Matches logical operators properly (using spaces on either side)

### DIFF
--- a/Cfscript.tmLanguage
+++ b/Cfscript.tmLanguage
@@ -461,7 +461,7 @@
                 </dict>
                 <dict>
                     <key>match</key>
-                    <string>(?i:(NOT|!|AND|&amp;&amp;|OR|\|\||XOR|EQV|IMP))</string>
+                    <string>\b(?i:(NOT|!|AND|&amp;&amp;|OR|\|\||XOR|EQV|IMP))\b</string>
                     <key>name</key>
                     <string>keyword.operator.logical.cfscript</string>
                 </dict>


### PR DESCRIPTION
I ran into an issue today where the "not" in this line was being highlighted (as cf syntax):

```
<cfset notice = "..." />
```

So I added the condition to only match when the logical operators have spaces on either side.
