### PR TITLE
Updates UUID on HTML+CFML.tmLanguage

### DIFF
--- a/HTML+CFML.tmLanguage
+++ b/HTML+CFML.tmLanguage
@@ -1317,6 +1317,6 @@
 	<key>scopeName</key>
 	<string>text.html.coldfusion</string>
 	<key>uuid</key>
-	<string>17994EC8-6B1D-11D9-AC3A-000D93589AF6</string>
+	<string>b2e03230-b205-4546-884e-ba107e964e46</string>
 </dict>
 </plist>


### PR DESCRIPTION
UUID was originally copied directly from HTML.tmLanguage.
HTML+CFML.tmLanguage now has its own UUID
