### PR TITLE
Fixes unescaped hash scope ref. 3b9e444

### DIFF
--- a/Coldfusion.tmLanguage
+++ b/Coldfusion.tmLanguage
@@ -1202,7 +1202,7 @@
 								)\#		# asserts closing hash
 							)</string>
 					<key>name</key>
-					<string>string.unescaped.hash.cfml</string>
+					<string>invalid.illegal.unescaped.hash.cfml</string>
 				</dict>
 				<!-- Match the start of interpolated hashes but ignore single hashes that are unmatched -->
 				<dict>

--- a/HTML+CFML.tmLanguage
+++ b/HTML+CFML.tmLanguage
@@ -1308,7 +1308,7 @@
 								)\#		# asserts closing hash
 							)</string>
 					<key>name</key>
-					<string>string.unescaped.hash.html</string>
+					<string>invalid.illegal.unescaped.hash.html</string>
 				</dict>
 				<!-- Match the start of interpolated hashes but ignore single hashes that are unmatched -->
 				<dict>


### PR DESCRIPTION
3b9e444c8fd3cdb3fb2c32b0570ab32547199923
