### PR TITLE
fixes #133

### DIFF
--- a/Cfscript.tmLanguage
+++ b/Cfscript.tmLanguage
@@ -256,7 +256,7 @@
                         </dict>
                         <dict>
                             <key>match</key>
-                            <string>(?i:false|true|no|yes)</string>
+                            <string>(?i)\b(false|true|no|yes)\b</string>
                             <key>name</key>
                             <string>constant.language.boolean.argument.cfscript</string>
                         </dict>


### PR DESCRIPTION
checks for a word boundary around true/false or yes/no so it doesn't incorrectly highlight matches within other words