### PR TITLE
fixes #156 autocomplete not working in ST3

### DIFF
--- a/dictionaries/cf10.py
+++ b/dictionaries/cf10.py
@@ -7631,13 +7631,5 @@ FUNCTIONS = {
 'trueFalseFormat(${1:value})':
 [
 
-],
-'private void function ${1:value}($0) {\n}':
-[
-
-],
-'private string function ${1:value}($0) {\n}':
-[
-
 ]
 }


### PR DESCRIPTION
Removed two invalid entries from the cf10.py FUNCTIONS array.

These were manipulated in ColdFusionAutoComplete::on_cfscript_all then passed to Sublime Text which choked on the spaces.