### PR TITLE
Added `git fetch` to ST3 Install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ The only installation method is via Git.
 cd Packages/
 git clone https://github.com/SublimeText/ColdFusion.git
 cd ColdFusion
+git fetch
 git checkout development
 ```
 * CFLIB Command is not currently working.


### PR DESCRIPTION
I always have to `git fetch` to checkout a branch that I do not have locally. This may be an issue for users not used to Git.